### PR TITLE
ci: allow to build binaries automatically

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -11,11 +11,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    
     - name: Use Node.js 14
       uses: actions/setup-node@v2
       with:
         node-version: 14
-        cache: 'npm'
 
     - name: Set up QEMU
       id: qemu

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -1,0 +1,33 @@
+name: Build binaries for UnblockNeteaseMusic
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14
+      uses: actions/setup-node@v2
+      with:
+        node-version: 14
+        cache: 'npm'
+
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
+    - name: Building to executable file
+      run: npx pkg .
+    
+    - name: Publishing to GitHub Releases
+      uses: softprops/action-gh-release@v1
+      with:
+        draft: true

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -25,9 +25,11 @@ jobs:
         platforms: all
 
     - name: Building to executable file
-      run: npx pkg .
+      run: npx pkg --compress Brotli .
     
     - name: Publishing to GitHub Releases
       uses: softprops/action-gh-release@v1
       with:
         draft: true
+        files: |
+          ./dist/*

--- a/package.json
+++ b/package.json
@@ -18,10 +18,8 @@
     "targets": [
       "node14-linux-arm64",
       "node14-win-arm64",
-      "node14-macos-arm64",
       "node14-linux-x64",
-      "node14-win-x64",
-      "node14-macos-x64"
+      "node14-win-x64"
     ],
     "outputPath": "dist"
   },


### PR DESCRIPTION
How will it work: https://github.com/tw-translation/UnblockNeteaseMusic/releases/tag/v0.27.2

It will be automatically run after tagging a release. **This commit should be squashed**

@1715173329 You should enable GitHub CI first to use this.