### PR TITLE
feat(ci/push-docker): allow to automatically push the Docker image on commit

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -15,9 +15,7 @@ on:
             - '.github/**/*'
 
     release:
-      types:
-        - prereleased
-        - published
+        types: [published]
 
 jobs:
     build:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -13,7 +13,9 @@ on:
             - '**.md'
 
     release:
-        types: [published]
+      types:
+        - prereleased
+        - published
 
 jobs:
     build:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -6,11 +6,13 @@ on:
             - 'enhanced'
         paths-ignore:
             - '**.md'
+            - '.github/**/*'
 
     pull_request:
         types: [opened, synchronize, reopened]
         paths-ignore:
             - '**.md'
+            - '.github/**/*'
 
     release:
       types:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,63 +9,63 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
-  push:
-    branches: [ enhanced ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ enhanced ]
-  schedule:
-    - cron: '45 22 * * 2'
+    push:
+        branches: [enhanced]
+    pull_request:
+        # The branches below must be a subset of the branches above
+        branches: [enhanced]
+    schedule:
+        - cron: '45 22 * * 2'
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
+    analyze:
+        name: Analyze
+        runs-on: ubuntu-latest
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
 
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
-        # Learn more:
-        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+        strategy:
+            fail-fast: false
+            matrix:
+                language: ['javascript']
+                # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+                # Learn more:
+                # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
 
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+            # Initializes the CodeQL tools for scanning.
+            - name: Initialize CodeQL
+              uses: github/codeql-action/init@v1
+              with:
+                  languages: ${{ matrix.language }}
+                  # If you wish to specify custom queries, you can do so here or in a config file.
+                  # By default, queries listed here will override any specified in a config file.
+                  # Prefix the list here with "+" to use these queries and those in the config file.
+                  # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+            # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+            # If this step fails, then you should remove it and run the build manually (see below)
+            - name: Autobuild
+              uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+            # ℹ️ Command-line programs to run using the OS shell.
+            # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+            # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+            #    and modify them (or add more) to build your code if your project
+            #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+            #- run: |
+            #   make bootstrap
+            #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+            - name: Perform CodeQL Analysis
+              uses: github/codeql-action/analyze@v1

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -1,0 +1,71 @@
+name: Build cross-platform docker image
+
+on:
+  push:
+    branches:
+      - 'enhanced'
+      - 'ci/docker-push'
+    paths-ignore:
+      - '**.md'
+
+  release:
+    types: [ published ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+  image: pan93412/unblock-netease-music-enhanced
+  develop_tag: latest
+  released_tag: release
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get the current tag name
+        uses: olegtarasov/get-tag@v2.1
+        id: tagName
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      -
+        name: Build and push the latest version
+        uses: docker/build-push-action@v2
+        if: github.event_name != 'release'
+        with:
+          context: .
+          platforms: ${{ env.platforms }}
+          push: true
+          tags: ${{ env.image }}:${{ env.develop_tag }}
+
+      -
+        name: Build and push the released version
+        uses: docker/build-push-action@v2
+        if: github.event_name == 'release'
+        with:
+          context: .
+          platforms: ${{ env.platforms }}
+          push: true
+          tags: >-
+            ${{ env.image }}:${{ env.develop_tag }},
+            ${{ env.image }}:${{ env.release_tag }},
+            ${{ env.image }}:${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'enhanced'
-      - 'ci/docker-push'
     paths-ignore:
       - '**.md'
       - '.github/**/*'

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -10,9 +10,7 @@ on:
       - '.github/**/*'
 
   release:
-    types:
-      - prereleased
-      - published
+    types: [ published ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -1,71 +1,66 @@
 name: Build cross-platform docker image
 
 on:
-  push:
-    branches:
-      - 'enhanced'
-    paths-ignore:
-      - '**.md'
-      - '.github/**/*'
+    push:
+        branches:
+            - 'enhanced'
+        paths-ignore:
+            - '**.md'
+            - '.github/**/*'
 
-  release:
-    types: [ published ]
+    release:
+        types: [published]
 
-  # Allows you to run this workflow manually from the Actions tab
-  workflow_dispatch:
+    # Allows you to run this workflow manually from the Actions tab
+    workflow_dispatch:
 
 env:
-  platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
-  image: pan93412/unblock-netease-music-enhanced
-  develop_tag: latest
-  released_tag: release
+    platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7
+    image: pan93412/unblock-netease-music-enhanced
+    develop_tag: latest
+    released_tag: release
 
 jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - name: Checkout
-        uses: actions/checkout@v2
+    build-and-publish:
+        runs-on: ubuntu-latest
+        steps:
+            # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+            - name: Checkout
+              uses: actions/checkout@v2
 
-      - name: Get the current tag name
-        uses: olegtarasov/get-tag@v2.1
-        id: tagName
+            - name: Get the current tag name
+              uses: olegtarasov/get-tag@v2.1
+              id: tagName
 
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
 
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+            - name: Set up Docker Buildx
+              uses: docker/setup-buildx-action@v1
 
-      -
-        name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      -
-        name: Build and push the latest version
-        uses: docker/build-push-action@v2
-        if: github.event_name != 'release'
-        with:
-          context: .
-          platforms: ${{ env.platforms }}
-          push: true
-          tags: ${{ env.image }}:${{ env.develop_tag }}
+            - name: Build and push the latest version
+              uses: docker/build-push-action@v2
+              if: github.event_name != 'release'
+              with:
+                  context: .
+                  platforms: ${{ env.platforms }}
+                  push: true
+                  tags: ${{ env.image }}:${{ env.develop_tag }}
 
-      -
-        name: Build and push the released version
-        uses: docker/build-push-action@v2
-        if: github.event_name == 'release'
-        with:
-          context: .
-          platforms: ${{ env.platforms }}
-          push: true
-          tags: >-
-            ${{ env.image }}:${{ env.develop_tag }},
-            ${{ env.image }}:${{ env.released_tag }},
-            ${{ env.image }}:${{ steps.tagName.outputs.tag }}
+            - name: Build and push the released version
+              uses: docker/build-push-action@v2
+              if: github.event_name == 'release'
+              with:
+                  context: .
+                  platforms: ${{ env.platforms }}
+                  push: true
+                  tags: >-
+                      ${{ env.image }}:${{ env.develop_tag }},
+                      ${{ env.image }}:${{ env.released_tag }},
+                      ${{ env.image }}:${{ steps.tagName.outputs.tag }}

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -9,7 +9,9 @@ on:
       - '**.md'
 
   release:
-    types: [ published ]
+    types:
+      - prereleased
+      - published
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -7,6 +7,7 @@ on:
       - 'ci/docker-push'
     paths-ignore:
       - '**.md'
+      - '.github/**/*'
 
   release:
     types:

--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -68,5 +68,5 @@ jobs:
           push: true
           tags: >-
             ${{ env.image }}:${{ env.develop_tag }},
-            ${{ env.image }}:${{ env.release_tag }},
+            ${{ env.image }}:${{ env.released_tag }},
             ${{ env.image }}:${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION
We pushed to `pan93412/unblock-netease-music-enhanced`.

It will build and push as  `develop` when received the new commit in `enhanced`; Similarly, it will build and push as `develop`, `released` and the current tag name when received the `published` event. You can also trigger it manually.

It currently builds four variant of Docker images: `linux/amd64`, `linux/arm64`, `linux/arm/v6`, and `linux/arm/v7`.

This resolved #110.
