### PR TITLE
修复pyncmd音源无法使用

### DIFF
--- a/src/provider/pyncmd.js
+++ b/src/provider/pyncmd.js
@@ -4,7 +4,7 @@ const request = require('../request');
 
 const track = (info) => {
 	const url =
-		'https://mos9527.tooo.top/ncm/pyncm/track/GetTrackAudio?song_ids=' +
+		'http://mos9527.tooo.top/ncm/pyncm/track/GetTrackAudio?song_ids=' +
 		info.id +
 		'&bitrate=' +
 		['999000', '320000'].slice(


### PR DESCRIPTION
推测是request模块的问题