### PR TITLE
Add source: yt-download.org

### DIFF
--- a/src/consts.js
+++ b/src/consts.js
@@ -8,6 +8,7 @@ const PROVIDERS = {
 	migu: require('./provider/migu'),
 	joox: require('./provider/joox'),
 	youtube: require('./provider/youtube'),
+	ytdownload: require('./provider/yt-download'),
 	bilibili: require('./provider/bilibili'),
 	pyncmd: require('./provider/pyncmd'),
 };

--- a/src/provider/match.js
+++ b/src/provider/match.js
@@ -46,13 +46,15 @@ const match = (id, source, data) => {
 
 const check = (url) => {
 	const song = { size: 0, br: null, url: null, md5: null };
-	let header = { range: 'bytes=0-8191' };
+	let header = { range: 'bytes=0-8191', 'accept-encoding': 'identity' };
 	const isHost = isHostWrapper(url);
 
 	if (isHost('bilivideo.com')) {
 		header.referer = 'https://www.bilibili.com/';
 	}
-
+	if (isHost('yt-download.org')) {
+		header.referer  = 'https://www.yt-download.org/';
+	}
 	return Promise.race([
 		request('GET', url, header),
 		new Promise((_, reject) => setTimeout(() => reject(504), 5 * 1000)),

--- a/src/provider/yt-download.js
+++ b/src/provider/yt-download.js
@@ -1,0 +1,56 @@
+const cache = require('../cache');
+const request = require('../request');
+
+// const proxy = require('url').parse('http://127.0.0.1:1080')
+const proxy = undefined;
+const key = process.env.YOUTUBE_KEY || null; // YouTube Data API v3
+
+const apiSearch = (info) => {
+	const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(
+		info.keyword
+	)}&type=video&key=${key}`;
+
+	return request('GET', url, { accept: 'application/json' }, null, proxy)
+		.then((response) => response.json())
+		.then((jsonBody) => {
+			const matched = jsonBody.items[0];
+			if (matched) return matched.id.videoId;
+			else return Promise.reject();
+		});
+};
+
+const search = (info) => {
+	const url = `https://www.youtube.com/results?search_query=${encodeURIComponent(
+		info.keyword
+	)}`;
+
+	return request('GET', url, {}, null, proxy)
+		.then((response) => response.body())
+		.then((body) => {
+			const initialData = JSON.parse(
+				body.match(/ytInitialData\s*=\s*([^;]+);/)[1]
+			);
+			const matched =
+				initialData.contents.twoColumnSearchResultsRenderer
+					.primaryContents.sectionListRenderer.contents[0]
+					.itemSectionRenderer.contents[0];
+			if (matched) return matched.videoRenderer.videoId;
+			else return Promise.reject();
+		});
+};
+
+const track = (id) => {
+	const url = `https://www.yt-download.org/api/button/mp3/${id}`;
+	const regex = /<a[^>]*href=["']([^"']*)["']/;
+
+	return request('GET', url)
+	.then((response) => response.body())
+	.then((body) => {
+		var matched = body.match(regex);
+		return matched ? matched[1] : Promise.reject();
+	});
+};
+
+const check = (info) => cache(key ? apiSearch : search, info).then(track);
+
+module.exports = { check, track };

--- a/src/provider/yt-download.js
+++ b/src/provider/yt-download.js
@@ -43,7 +43,7 @@ const track = (id) => {
 	const url = `https://www.yt-download.org/api/button/mp3/${id}`;
 	const regex = /<a[^>]*href=["']([^"']*)["']/;
 
-	return request('GET', url)
+	return request('GET', url, {}, null, proxy)
 	.then((response) => response.body())
 	.then((body) => {
 		var matched = body.match(regex);

--- a/src/server.js
+++ b/src/server.js
@@ -127,6 +127,9 @@ const proxy = {
 					req.headers['referer'] = 'https://www.bilibili.com/';
 					req.headers['user-agent'] = 'okhttp/3.4.1';
 				}
+				if (isHost(req.url, 'yt-download.org')) {
+					req.headers['referer'] = 'https://www.yt-download.org/';
+				}
 				const url = parse(req.url);
 				const options = request.configure(req.method, url, req.headers);
 				ctx.proxyReq = request


### PR DESCRIPTION
Youtube's AAC is making macOS ver. 2.3.5 (856) vomiting:

```
[2021-8-27 1:47:11][info]??? _$load, , {"playId":"327565_4_32410","playid":"327565_4_32410","volumeDelta":0,"songName":"跟着感觉走","albumName":"妹力四射","artistName":"张惠妹/苏芮","albumId":"album32410","url":"http://p4.music.126.net/4vHbk4FulFbwvoaRQOVAeg==/113249697662044.jpg","starttime":0,"duration":291.92,"bitrate":128,"playbrt":128,"type":4,"md5":"916575b000784a125ddf988a15a5c0bc","format":"mp3","songId":"327565","fileSize":0,"musicurl":"http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3","songType":"normal"}
AudioStreamer : remote audio provider will init with url : http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3
AudioStreamer : remote audio provider <NTESRemoteAudioProvider: 0x7fc2a8500470> init with urls : (
    "http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3",
    "http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3",
    "http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3",
    "http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3"
)
AudioStreamer : <NTESAudioStreamer: 0x600003f15380> play url setted : http://music.163.com/package/aHR0cHM6Ly93d3cueXQtZG93bmxvYWQub3JnL2Rvd25sb2FkL3dOclpQZUE1U09RL21wMy8zMjAvMTYzMDA0NjgyOC82Y2ZhMjc5NzFhNzg2ZTA1NGI1YjQzOWIzYjA5YjhjNjUzNjUwNTlhYTYwOGEwZjdjMDlmN2QxOGNlOWZkYTEzLzA=/327565.mp3
AudioStreamer error occurred: 未能完成该操作。（com.netease.audiostreamer.error 错误 2002。）, error code: 2002, userInfo: {
}
AudioStreamer : <NTESAudioStreamer: 0x600003f15380> statusChanged, status:NTESAudioStreamerError
[2021-8-27 1:47:12][info]??? __onAudioPlayerBuffering, , 0
[2021-8-27 1:47:12][info]??? __doLoadingStateChange, , true
[2021-8-27 1:47:12][info]??? __onAudioPlayerEnd, , {"code":9999}
[2021-8-27 1:47:12][info]??? __doPlayEnd, , {"reason":"err","code":9999}
[2021-8-27 1:47:12][info]??? __doPlayingStateChange, , false
[2021-8-27 1:47:12][warn]__onPlayEnd, player/index.js, {"playId":"327565_4_32410","reason":"err","code":9999}
```

Meanwhile yt-download.org has a nice [Developer API](https://www.yt-download.org/developers) - works like a drop in replacement.

In case this method is no longer working I may have to write something that can be deployed as web service that does similar conversion. Unfortunately media encoding is pretty CPU heavy, pushing almost all cool serverless services out of reach - but that's for another day.