### PR TITLE
feat(yt-dlp, youtube-dl): remove redundant call

### DIFF
--- a/src/provider/youtube-dl.js
+++ b/src/provider/youtube-dl.js
@@ -47,24 +47,18 @@ async function getUrl(args) {
 	}
 }
 
-const search = async (info) => {
-	const { id } = await getUrl(dlArguments(byKeyword(info.keyword)));
-	return id;
-};
-
-const track = async (id) => {
-	const { url } = await getUrl(dlArguments(byId(id)));
+const track = async (info) => {
+	const { url } = await getUrl(dlArguments(byKeyword(info.keyword)));
 	return url;
 };
 
 const cs = getManagedCacheStorage('youtube-dl');
 const check = (info) =>
 	cs
-		.cache(info, () => search(info))
-		.then(track)
+		.cache(info, () => track(info))
 		.catch((e) => {
 			if (e) logger.error(e);
 			throw e;
 		});
 
-module.exports = { check, track };
+module.exports = { check };

--- a/src/provider/yt-dlp.js
+++ b/src/provider/yt-dlp.js
@@ -47,24 +47,18 @@ async function getUrl(args) {
 	}
 }
 
-const search = async (info) => {
-	const { id } = await getUrl(dlArguments(byKeyword(info.keyword)));
-	return id;
-};
-
-const track = async (id) => {
-	const { url } = await getUrl(dlArguments(byId(id)));
+const track = async (info) => {
+	const { url } = await getUrl(dlArguments(byKeyword(info.keyword)));
 	return url;
 };
 
 const cs = getManagedCacheStorage('yt-dlp');
 const check = (info) =>
 	cs
-		.cache(info, () => search(info))
-		.then(track)
+		.cache(info, () => track(info))
 		.catch((e) => {
 			if (e) logger.error(e);
 			throw e;
 		});
 
-module.exports = { check, track };
+module.exports = { check };


### PR DESCRIPTION
playurl is already returned in search stage, let's use it directly.

Fixed #1449