### PR TITLE
always upgrade http to https during mitm

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -131,7 +131,7 @@ const proxy = {
 					req.headers['referer'] = 'https://www.bilibili.com/';
 					req.headers['user-agent'] = 'okhttp/3.4.1';
 				}
-				const url = parse(req.url);
+				const url = parse(req.url.replace("http://", 'https://'));
 				const options = request.configure(req.method, url, req.headers);
 				ctx.proxyReq = request
 					.create(url)(options)


### PR DESCRIPTION
I have a server running behind a reverse proxy. the reverse proxy will request the server via http. as a result, the mitm proxy in the server will try to request api via http. It returns the following error

```
{
  "code": -462,
  "data": {
    "actionCode": null,
    "verifyType": 50,
    "verifyId": 1,
    "verifyUrl": "",
    "blockText": "网络太拥挤，请稍候再试。",
    "verifyToken": null,
    "btnText": null,
    "orpheusUrl": null,
    "frontRuleIds": null,
    "params": {
      "event_id": ...
      "sign": ...
    },
    "url": null,
    "urlAutoOpen": 0,
    "orpheusUrlParamAppend": null
  },
  "message": "网络太拥挤，请稍候再试。"
}
```

looks like the API will just reject any http request. always use https in mitm proxy can resolve the problem. I think it's a reasonable change since every endpoint exposed by providers is https