### PR TITLE
fix: 适配新版客户端，修复 nativeFetch 导致的请求参数错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ checknetisolation loopbackexempt -a -n="1F8B0F94.122165AE053F_j2p0p5q0044a6"
 <Server IP> music.163.com
 <Server IP> interface.music.163.com
 <Server IP> interface3.music.163.com
+<Server IP> interfacepc.music.163.com
 <Server IP> interface.music.163.com.163jiasu.com
 <Server IP> interface3.music.163.com.163jiasu.com
 ```

--- a/src/hook.js
+++ b/src/hook.js
@@ -170,7 +170,7 @@ hook.request.before = (ctx) => {
 					req.url.includes('/eapi/cloud/upload/check')
 				)
 					return; // look living/cloudupload eapi can not be decrypted
-				if (req.headers['sec-ch-ua'])
+				if (req.headers['Accept-Encoding'])
 					req.headers['Accept-Encoding'] = 'gzip, deflate'; // https://blog.csdn.net/u013022222/article/details/51707352
 				if (body) {
 					const netease = {};

--- a/src/hook.js
+++ b/src/hook.js
@@ -45,6 +45,7 @@ hook.target.host = new Set([
 	'music.163.com',
 	'interface.music.163.com',
 	'interface3.music.163.com',
+	'interfacepc.music.163.com',
 	'apm.music.163.com',
 	'apm3.music.163.com',
 	'interface.music.163.com.163jiasu.com',
@@ -169,7 +170,8 @@ hook.request.before = (ctx) => {
 					req.url.includes('/eapi/cloud/upload/check')
 				)
 					return; // look living/cloudupload eapi can not be decrypted
-				req.headers['Accept-Encoding'] = 'gzip, deflate'; // https://blog.csdn.net/u013022222/article/details/51707352
+				if (req.headers['sec-ch-ua'])
+					req.headers['Accept-Encoding'] = 'gzip, deflate'; // https://blog.csdn.net/u013022222/article/details/51707352
 				if (body) {
 					const netease = {};
 					netease.pad = (body.match(/%0+$/) || [''])[0];


### PR DESCRIPTION
fix #1676 https://github.com/UnblockNeteaseMusic/luci-app-unblockneteasemusic/issues/337

最新版的网易云音乐 Windows 客户端在启用 UNM 代理后，许多页面（如我喜欢的音乐、用户详情页等）无法加载，并提示 "请求参数错误"。

经过分析，定位到问题由两个主要变更导致：

1.  **新的 API Host：** 新版客户端开始使用 `interfacepc.music.163.com` 作为其主要的 API Host，而不再是旧版的 `interface.music.163.com`。这导致 UNM 无法 Hook 到新版客户端的请求。
2.  **引入 `nativeFetch`：** 新版客户端在 Windows 平台下引入了 `o.Network.useNativeFetch` 逻辑。
    * 当此项为 `true` 时，客户端会使用原生的网络请求方法，而非浏览器的 `fetch` API。<img width="526" height="84" alt="image" src="https://github.com/user-attachments/assets/992a08fc-a231-47af-bda2-4a05df759a56" />
    * 当此项为 `false` (或被强制修改为 `false`) 时，客户端回退到使用浏览器 `fetch`，此时（在添加新 Host 后）UNM 可以正常工作。


**根本原因：**

进一步排查发现，当 `nativeFetch` 开启时，客户端所新增的 nativeFetch 似乎**无法正确处理 GZIP 压缩的响应**。

而 UNM 此前会**无条件**为所有经过代理的请求添加 `Accept-Encoding: gzip, deflate` 请求头。

* 对于 UNM **明确 Hook 的 API**（如 `api/song/enhance/player/url/v1`），UNM 自身会处理响应体的 GZIP，因此播放功能正常。
* 对于 UNM **未 Hook 的 API**（如获取登录信息、用户详情页等），UNM 只是透传了请求。它添加了 `Accept-Encoding` 头，导致服务端返回了 GZIP 压缩数据，而客户端的 `nativeFetch` 无法解析，最终导致数据加载失败，并报错 "请求参数错误"（可能是因为解析失败导致后续逻辑中确实缺少了参数，如我喜欢的音乐提示该错误是因为参数中传递了 `id: undefined`）。

此 PR 采用了两项关键修改：

1.  **添加新 Host：** 将 `interfacepc.music.163.com` 添加到 Hook 列表，确保 UNM 能够拦截新版客户端的请求。
2.  **条件性添加 `Accept-Encoding`：** 仅当 UNM 收到的原始请求头中 已存在 Accept-Encoding 字段时，才将其覆盖设置为 Accept-Encoding: gzip, deflate。

修改后，无论 `nativeFetch` 开启与否，新旧版客户端均可正常工作。
<img width="1048" height="749" alt="image" src="https://github.com/user-attachments/assets/3a70a120-efcb-4d45-aa52-518f2389bc1d" />
